### PR TITLE
feat: v0.0.10 — default model, thinking & context budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [0.0.10] — Default model, thinking & context budget
+
+### Changes
+- Default model & thinking level: save from picker, persist across sessions
+- Context budget setting: control when auto-compaction triggers (100K–1M or model default)
+- Budget shown in status bar; click to change
+
 ## [0.0.9] — UX polish
 
 ### Changes

--- a/media/main.js
+++ b/media/main.js
@@ -547,6 +547,11 @@
       }
       if (costStr) parts.push(costStr);
 
+      // Context budget override indicator
+      if (data.contextBudget > 0) {
+        parts.push("budget:" + formatTokens(data.contextBudget));
+      }
+
       // Context %
       if (u.contextWindow > 0 && u.contextPercent !== null) {
         var ctx = u.contextPercent.toFixed(1) + "%/" + formatTokens(u.contextWindow);
@@ -1819,6 +1824,14 @@
   if (statusEffortPicker) {
     statusEffortPicker.addEventListener("click", function () {
       vscode.postMessage({ type: "pickEffort" });
+    });
+  }
+
+  // Context budget picker — click usage area to change
+  var statusUsage = document.getElementById("status-usage");
+  if (statusUsage) {
+    statusUsage.addEventListener("click", function () {
+      vscode.postMessage({ type: "pickContextBudget" });
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Jack Noppé",
   "displayName": "Pi Code Gui",
   "description": "Native VS Code editor experience for Pi coding agent",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "license": "MIT",
   "sponsor": {
     "url": "https://github.com/sponsors/NimbleTronAI"
@@ -252,6 +252,27 @@
           "type": "boolean",
           "default": true,
           "description": "Register custom slash commands (e.g. /fix-diagnostics, /explain-code)"
+        },
+        "pi-code-gui.defaultModelProvider": {
+          "type": "string",
+          "default": "",
+          "description": "Default model provider (e.g. 'anthropic'). Empty = auto-detect first available."
+        },
+        "pi-code-gui.defaultModelId": {
+          "type": "string",
+          "default": "",
+          "description": "Default model ID (e.g. 'claude-sonnet-4-5'). Requires defaultModelProvider to be set."
+        },
+        "pi-code-gui.defaultThinkingLevel": {
+          "type": "string",
+          "default": "off",
+          "enum": ["off", "minimal", "low", "medium", "high", "xhigh"],
+          "description": "Default thinking level for new sessions"
+        },
+        "pi-code-gui.contextBudget": {
+          "type": "number",
+          "default": 0,
+          "description": "Per-session token budget. 0 = use model default. Increase for longer conversations before auto-compaction."
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1062,14 +1062,29 @@ async function pickModelForSession(ps: PiService): Promise<{ provider: string; m
   }
 
   const currentId = ps.model?.id;
-  const items = models.map((m) => ({
-    label: `${m.label}${m.modelId === currentId ? " $(check)" : ""}`,
-    description: m.provider,
-    provider: m.provider,
-    modelId: m.modelId,
-  }));
-  const picked = await vscode.window.showQuickPick(items, { placeHolder: "Select model" });
+  const defModel = ps.getDefaultModel();
+  const items = models.map((m) => {
+    const isDefault = defModel && m.provider === defModel.provider && m.modelId === defModel.id;
+    return {
+      label: `${m.label}${m.modelId === currentId ? " $(check)" : ""}${isDefault ? " \u2605" : ""}`,
+      description: m.provider,
+      provider: m.provider,
+      modelId: m.modelId,
+      isDefault,
+    };
+  });
+  const picked = await vscode.window.showQuickPick(items, { placeHolder: "Select model (\u2605 = default)" });
   if (!picked || typeof picked === "string") { return null; }
+
+  // Offer to save as default
+  if (!picked.isDefault) {
+    const save = await vscode.window.showQuickPick(
+      [{ label: "\u2605 Save as default", description: "Use this model for future sessions" }],
+      { placeHolder: `Use as default?` },
+    );
+    if (save) { ps.saveDefaultModel(); }
+  }
+
   return { provider: picked.provider, modelId: picked.modelId };
 }
 

--- a/src/pi-service.ts
+++ b/src/pi-service.ts
@@ -469,6 +469,21 @@ export class PiService {
       };
     }
 
+    // ── Override with user's default model from VS Code settings ──
+    const cfg = vscode.workspace.getConfiguration("pi-code-gui");
+    const defProvider = cfg.get<string>("defaultModelProvider");
+    const defModelId = cfg.get<string>("defaultModelId");
+    if (defProvider && defModelId) {
+      const defModel = this.modelRegistry.find(defProvider, defModelId) ?? AI.getModel(defProvider, defModelId);
+      if (defModel) { model = defModel; }
+    }
+
+    // ── Override context budget from VS Code settings ──
+    const contextBudget = cfg.get<number>("contextBudget") ?? 0;
+    if (contextBudget > 0) {
+      model = { ...model, contextWindow: contextBudget };
+    }
+
     this._model = { id: model.id, name: model.name, provider: model.provider };
 
     // ── Step 5: ResourceLoader ─────────────────────────
@@ -545,7 +560,7 @@ export class PiService {
 
     // ── Step 8: Restore model & thinking from session file (if resuming) ──
     let resumeModel: any = model;
-    let resumeThinkingLevel = "off";
+    let resumeThinkingLevel = cfg.get<string>("defaultThinkingLevel") ?? "off";
     if (openPath && this.sessionManager) {
       const entries = this.sessionManager.getEntries?.();
       if (Array.isArray(entries)) {
@@ -910,6 +925,8 @@ export class PiService {
 
   private reportStatus() {
     const stats = this.getUsageStats();
+    const cfg = vscode.workspace.getConfiguration("pi-code-gui");
+    const budget = cfg.get<number>("contextBudget") ?? 0;
     this.emit({
       type: "status-update",
       data: {
@@ -919,6 +936,7 @@ export class PiService {
         isStreaming: this._isStreaming,
         sessionId: this.sessionId ?? undefined,
         usage: stats,
+        contextBudget: budget,
       },
     });
   }
@@ -1099,6 +1117,47 @@ export class PiService {
     if (!this.session) { return; }
     this.session.setThinkingLevel(level);
     this._thinkingLevel = level;
+    this.reportStatus();
+  }
+
+  // ── Default model / thinking persistence ──────────────
+
+  /** Save the current model as the default for future sessions. */
+  saveDefaultModel() {
+    if (!this._model?.provider || !this._model?.id) { return; }
+    const cfg = vscode.workspace.getConfiguration("pi-code-gui");
+    cfg.update("defaultModelProvider", this._model.provider, vscode.ConfigurationTarget.Global);
+    cfg.update("defaultModelId", this._model.id, vscode.ConfigurationTarget.Global);
+  }
+
+  /** Save the current thinking level as the default for future sessions. */
+  saveDefaultThinking() {
+    const cfg = vscode.workspace.getConfiguration("pi-code-gui");
+    cfg.update("defaultThinkingLevel", this._thinkingLevel, vscode.ConfigurationTarget.Global);
+  }
+
+  /** Get the configured default model (if any). */
+  getDefaultModel(): { provider: string; id: string } | null {
+    const cfg = vscode.workspace.getConfiguration("pi-code-gui");
+    const provider = cfg.get<string>("defaultModelProvider");
+    const id = cfg.get<string>("defaultModelId");
+    return (provider && id) ? { provider, id } : null;
+  }
+
+  /** Get the configured default thinking level. */
+  getDefaultThinking(): string {
+    return vscode.workspace.getConfiguration("pi-code-gui").get<string>("defaultThinkingLevel") ?? "off";
+  }
+
+  /** Get the current context budget (0 = model default). */
+  getContextBudget(): number {
+    return vscode.workspace.getConfiguration("pi-code-gui").get<number>("contextBudget") ?? 0;
+  }
+
+  /** Save context budget setting (requires restart to take effect). */
+  async setContextBudget(budget: number) {
+    const cfg = vscode.workspace.getConfiguration("pi-code-gui");
+    await cfg.update("contextBudget", budget, vscode.ConfigurationTarget.Global);
     this.reportStatus();
   }
 

--- a/src/webview-panel.ts
+++ b/src/webview-panel.ts
@@ -185,6 +185,11 @@ export class PiWebviewPanel {
             this.piService.emitScopedModels();
             break;
 
+          // Context budget picker
+          case "pickContextBudget":
+            this.triggerContextBudgetPicker();
+            break;
+
           // Request settings state (#2, #8)
           case "resendUserMessage":
             if (message.text) {
@@ -1406,7 +1411,7 @@ export class PiWebviewPanel {
     <span class="status-item clickable" id="status-effort-picker" title="Click to change effort (only for certain models)">
       <span id="status-effort"></span>
     </span>
-    <span class="status-item" id="status-usage">
+    <span class="status-item clickable" id="status-usage" title="Click to set context budget">
       <span id="status-usage-text"></span>
     </span>
     <span class="status-item clickable" id="status-settings-btn" title="Settings">
@@ -1459,17 +1464,32 @@ export class PiWebviewPanel {
     }
 
     const currentId = ps.model?.id;
-    const items = modelItems.map((m) => ({
-      label: `${m.label}${m.modelId === currentId ? " $(check)" : ""}`,
-      description: m.description || m.provider,
-      provider: m.provider,
-      modelId: m.modelId,
-    }));
+    const defModel = ps.getDefaultModel();
+    const items = modelItems.map((m) => {
+      const isDefault = defModel && m.provider === defModel.provider && m.modelId === defModel.id;
+      const isCurrent = m.modelId === currentId;
+      return {
+        label: `${m.label}${isDefault ? " \u2605" : ""}${isCurrent ? " $(check)" : ""}`,
+        description: m.description || m.provider,
+        provider: m.provider,
+        modelId: m.modelId,
+        isDefault,
+      };
+    });
 
-    const picked = await vscode.window.showQuickPick(items, { placeHolder: "Select model" });
+    const picked = await vscode.window.showQuickPick(items, { placeHolder: "Select model (\u2605 = default)" });
     if (!picked) { return; }
 
     await ps.setModel(picked.provider, picked.modelId);
+
+    // Offer to save as default if not already
+    if (!picked.isDefault) {
+      const save = await vscode.window.showQuickPick(
+        [{ label: "\u2605 Save as default", description: "Use this model for future sessions" }],
+        { placeHolder: `Use ${picked.label.replace(/ \u2605| \$\(check\)/g, "")} as the default?` },
+      );
+      if (save) { ps.saveDefaultModel(); }
+    }
   }
 
   /** Open VS Code quick pick to pick thinking level */
@@ -1484,14 +1504,56 @@ export class PiWebviewPanel {
       { label: "xhigh", description: "Maximum thinking" },
     ];
     const current = ps.thinkingLevel;
-    const items = levels.map((l) => ({
-      label: `${l.label === current ? "$(check) " : ""}${l.label}`,
-      description: l.description,
-      level: l.label,
-    }));
-    const picked = await vscode.window.showQuickPick(items, { placeHolder: "Select thinking level" });
+    const defLevel = ps.getDefaultThinking();
+    const items = levels.map((l) => {
+      const isDefault = l.label === defLevel;
+      return {
+        label: `${l.label === current ? "$(check) " : ""}${l.label}${isDefault ? " \u2605" : ""}`,
+        description: l.description,
+        level: l.label,
+        isDefault,
+      };
+    });
+    const picked = await vscode.window.showQuickPick(items, { placeHolder: "Select thinking level (\u2605 = default)" });
     if (!picked) { return; }
     await ps.setThinkingLevel(picked.level);
+
+    // Offer to save as default if not already
+    if (!picked.isDefault) {
+      const save = await vscode.window.showQuickPick(
+        [{ label: "\u2605 Save as default", description: "Use this thinking level for future sessions" }],
+        { placeHolder: `Use "${picked.level}" thinking as the default?` },
+      );
+      if (save) { ps.saveDefaultThinking(); }
+    }
+  }
+
+  /** Open VS Code quick pick to pick context budget */
+  private async triggerContextBudgetPicker() {
+    const ps = this.piService;
+    const current = ps.getContextBudget();
+    const budgets = [
+      { label: "Model default", value: 0, description: "Use the model's built-in context window" },
+      { label: "100K tokens", value: 100000, description: "Compact at ~0.1M" },
+      { label: "200K tokens", value: 200000, description: "Compact at ~0.2M" },
+      { label: "500K tokens", value: 500000, description: "Compact at ~0.5M" },
+      { label: "1M tokens", value: 1000000, description: "Compact at ~1M" },
+    ];
+    const items = budgets.map((b) => ({
+      label: `${b.label}${b.value === current ? " $(check)" : ""}`,
+      description: b.description,
+      value: b.value,
+    }));
+    const picked = await vscode.window.showQuickPick(items,
+      { placeHolder: "Select per-session token budget. Takes effect on next session." },
+    );
+    if (!picked) { return; }
+    await ps.setContextBudget(picked.value);
+    vscode.window.showInformationMessage(
+      picked.value === 0
+        ? "Context budget: model default. Restart session to apply."
+        : `Context budget set to ${formatBudget(picked.value)}. Restart session to apply.`,
+    );
   }
 
   /** Open VS Code quick pick to pick effort */
@@ -1519,4 +1581,10 @@ export class PiWebviewPanel {
     this.disposables.forEach((d) => d.dispose());
     this.panel?.dispose();
   }
+}
+
+function formatBudget(tokens: number): string {
+  if (tokens < 1000) { return tokens.toString(); }
+  if (tokens < 1000000) { return (tokens / 1000).toFixed(0) + "K"; }
+  return (tokens / 1000000).toFixed(1) + "M";
 }


### PR DESCRIPTION
- Save default model & thinking level from picker, persist via VS Code settings
- Context budget setting (100K–1M or model default) shown in status bar, click to pick
- ★ indicators in model/thinking pickers show current defaults
- pnpm/action-setup@v4 → v6 (Node 20 deprecation)