### PR TITLE
Show "known" model pricing in the model picker. 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,11 +14,15 @@
 
     "customizations": {
         "vscode": {
+            "settings": {
+                "pi-code-gui.systemPromptAppend": "/workspace/pi-code-gui/.pi/APPEND_SYSTEM.md"
+            },
             "extensions": [
                 "dbaeumer.vscode-eslint",
                 "connor4312.esbuild-problem-matchers",
                 "ms-vscode.extension-test-runner",
-                "github.vscode-pull-request-github"
+                "github.vscode-pull-request-github",
+                "nimbletron.pi-code-gui"
             ]
         }
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.0.21] — Model picker pricing & picker de-duplication
+
+### Added
+- **Model picker** shows SDK-reported pricing and context window in the detail line (e.g. `$3/$15 per M tokens · 200K context`). No pricing shown when the SDK isn't available.
+
+
 ## [0.0.20] — Slash commands, fork/clone, and UX hardening
 
 ### Changed

--- a/agent-wiki/architecture/pi-service.md
+++ b/agent-wiki/architecture/pi-service.md
@@ -35,6 +35,12 @@ independently, leading to duplicated init logic and inconsistent error handling.
   panel, extension commands) subscribe to typed `PiServiceEvent` emissions.
 - **User actions** — `sendPrompt`, `abort`, `cycleModel`, `setThinkingLevel`,
   `setEffort`, `login`, `logout`, `toggleAutoCompaction`, `toggleAutoRetry`.
+- **Interactive pickers** — `pickModel()` and `pickThinkingLevel()` provide
+  unified QuickPick dialogs (with ★ default / ✓ current indicators and
+  save-as-default prompts). These replaced duplicated implementations that
+  previously lived in `extension.ts` and `webview-panel.ts`. `pickModel()`
+  also surfaces SDK-reported pricing and context window in the `detail` field via
+  `PiService.formatModelDetail()`.
 - **Session listing** (`PiService.listSessions`, `PiService.deleteSessionFile`) —
   static methods for the Past Sessions tree view.
 
@@ -44,4 +50,4 @@ independently, leading to duplicated init logic and inconsistent error handling.
 - [Event Translation](event-translation.md) — how SDK events become PiServiceEvent types
 - [SDK Resolution & Init](../operations/sdk-resolution.md) — detailed walkthrough of the init sequence
 
-> **Last updated:** 2026-05-15 — initial documentation
+> **Last updated:** 2025-05-15 — added pickModel/pickThinkingLevel, de-duplicated pickers, added model pricing

--- a/agent-wiki/log.md
+++ b/agent-wiki/log.md
@@ -8,6 +8,7 @@ pass performed), `archive` (page moved to archive).
 ## [2026-05-15] ingest | Bootstrap — wiki structure initialized from Pi template (discipline pages, index, log, archive)
 ## [2026-05-15] ingest | Architecture — Session Window (`architecture/session-window.md`)
 ## [2026-05-15] ingest | Architecture — PiService (`architecture/pi-service.md`)
+## [2026-05-15] update | PiService — added pickModel/pickThinkingLevel, de-duplicated pickers from extension.ts and webview-panel.ts, added model pricing display
 ## [2026-05-15] ingest | Architecture — Webview Panel (`architecture/webview-panel.md`)
 ## [2026-05-15] ingest | Architecture — Bridge Tools (`architecture/bridge-tools.md`)
 ## [2026-05-15] ingest | Architecture — Event Translation (`architecture/event-translation.md`)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Jack Noppé",
   "displayName": "Pi Code Gui",
   "description": "Native VS Code editor experience for Pi coding agent",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "license": "MIT",
   "sponsor": {
     "url": "https://github.com/sponsors/NimbleTronAI"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -579,10 +579,7 @@ export async function activate(context: vscode.ExtensionContext) {
         piWarn(`pickSessionModel: session not initialized (sessionId=${sessionId})`);
         return;
       }
-      // Open model picker for this specific session via its PiService
-      const pf = await pickModelForSession(sw.piService);
-      if (pf) {
-        await sw.piService.setModel(pf.provider, pf.modelId);
+      if (await sw.piService.pickModel()) {
         sessionTreeProvider?.refresh();
       }
     }),
@@ -596,9 +593,7 @@ export async function activate(context: vscode.ExtensionContext) {
         piWarn(`pickSessionThinking: session not initialized (sessionId=${sessionId})`);
         return;
       }
-      const level = await pickThinkingLevel(sw.piService.thinkingLevel);
-      if (level) {
-        await sw.piService.setThinkingLevel(level);
+      if (await sw.piService.pickThinkingLevel()) {
         sessionTreeProvider?.refresh();
       }
     }),
@@ -613,9 +608,7 @@ export async function activate(context: vscode.ExtensionContext) {
         return;
       }
       sw.webviewPanel.show();
-      const pf = await pickModelForSession(sw.piService);
-      if (pf) {
-        await sw.piService.setModel(pf.provider, pf.modelId);
+      if (await sw.piService.pickModel()) {
         sessionTreeProvider?.refresh();
       }
     }),
@@ -630,9 +623,7 @@ export async function activate(context: vscode.ExtensionContext) {
         return;
       }
       sw.webviewPanel.show();
-      const level = await pickThinkingLevel(sw.piService.thinkingLevel);
-      if (level) {
-        await sw.piService.setThinkingLevel(level);
+      if (await sw.piService.pickThinkingLevel()) {
         sessionTreeProvider?.refresh();
       }
     }),
@@ -1623,80 +1614,6 @@ function formatRelativeTime(date: Date): string {
 }
 
 // ── UI pickers for per-session model / thinking level ──────
-
-async function pickModelForSession(ps: PiService): Promise<{ provider: string; modelId: string } | null> {
-  // Use dynamic model discovery from the registry
-  let models: Array<{ label: string; provider: string; modelId: string }> = [];
-
-  try {
-    const available = await ps.getAvailableModels();
-    if (available.length > 0) {
-      models = available.map((m) => ({
-        label: m.name || m.id,
-        provider: m.provider,
-        modelId: m.id,
-      }));
-    }
-  } catch (e: any) { console.warn(`[pi-gui] pickModelForSession: getAvailableModels failed (${e.message}), using static fallback`); }
-
-  // Fallback: static list of common models
-  if (models.length === 0) {
-    models = [
-      { label: "Claude Sonnet 4.5", provider: "anthropic", modelId: "claude-sonnet-4-5" },
-      { label: "Claude Haiku 4.5", provider: "anthropic", modelId: "claude-haiku-4-5" },
-      { label: "Claude Opus 4.5", provider: "anthropic", modelId: "claude-opus-4-5" },
-      { label: "GPT 4o", provider: "openai", modelId: "gpt-4o" },
-      { label: "Gemini 2.5 Pro", provider: "google", modelId: "gemini-2.5-pro" },
-      { label: "DeepSeek V3", provider: "deepseek", modelId: "deepseek-chat" },
-    ];
-  }
-
-  const currentId = ps.model?.id;
-  const defModel = ps.getDefaultModel();
-  const items = models.map((m) => {
-    const isDefault = defModel && m.provider === defModel.provider && m.modelId === defModel.id;
-    return {
-      label: `${m.label}${m.modelId === currentId ? " $(check)" : ""}${isDefault ? " \u2605" : ""}`,
-      description: m.provider,
-      provider: m.provider,
-      modelId: m.modelId,
-      isDefault,
-    };
-  });
-  const picked = await vscode.window.showQuickPick(items, { placeHolder: "Select model (\u2605 = default)" });
-  if (!picked || typeof picked === "string") { return null; }
-
-  // Offer to save as default
-  if (!picked.isDefault) {
-    const save = await vscode.window.showQuickPick(
-      [{ label: "\u2605 Save as default", description: "Use this model for future sessions" }],
-      { placeHolder: `Use as default?` },
-    );
-    if (save) { ps.saveDefaultModel(); }
-  }
-
-  return { provider: picked.provider, modelId: picked.modelId };
-}
-
-async function pickThinkingLevel(current: string): Promise<string | null> {
-  const levels = ["off", "minimal", "low", "medium", "high", "xhigh"];
-  const items = levels.map((l) => ({
-    label: `${l === current ? "$(check) " : ""}${l}`,
-    description: describeLevel(l),
-    level: l,
-  }));
-  const picked = await vscode.window.showQuickPick(items, { placeHolder: "Select thinking level" });
-  if (!picked || typeof picked === "string") { return null; }
-  return picked.level;
-}
-
-function describeLevel(l: string): string {
-  const m: Record<string, string> = {
-    off: "None", minimal: "Minimal", low: "Brief",
-    medium: "Balanced", high: "Extended", xhigh: "Maximum",
-  };
-  return m[l] ?? "";
-}
 
 class SessionTreeItem extends vscode.TreeItem {
   public sessionId?: string;

--- a/src/phase3-commands.ts
+++ b/src/phase3-commands.ts
@@ -29,20 +29,7 @@ export function registerPhase3Commands(
   });
 
   safeRegister(context, "pi-code-gui.pickThinkingLevel", async () => {
-    const levels = ["off", "minimal", "low", "medium", "high", "xhigh"];
-    const cur = piService.thinkingLevel;
-    const items = levels.map(l => ({
-      label: `${l === cur ? "$(check) " : ""}${l}`,
-      description: describeLevel(l),
-      level: l,
-    }));
-    const picked = await vscode.window.showQuickPick(items, {
-      placeHolder: "Select thinking level (Shift+Tab)",
-    });
-    if (picked && typeof picked !== "string") {
-      await piService.setThinkingLevel(picked.level);
-      vscode.window.showInformationMessage(`Thinking: ${picked.level}`);
-    }
+    await piService.pickThinkingLevel();
   });
 
   safeRegister(context, "pi-code-gui.cycleThinkingLevel", async () => {
@@ -93,14 +80,6 @@ export function registerPhase3Commands(
   safeRegister(context, "pi-code-gui.exportSession", async () => {
     vscode.window.showInformationMessage("Export via /export command in chat.");
   });
-}
-
-function describeLevel(l: string): string {
-  const m: Record<string, string> = {
-    off: "None", minimal: "Minimal", low: "Brief",
-    medium: "Balanced", high: "Extended", xhigh: "Maximum",
-  };
-  return m[l] ?? "";
 }
 
 function nextLevel(cur: string): string {

--- a/src/pi-service.ts
+++ b/src/pi-service.ts
@@ -1599,15 +1599,135 @@ export class PiService {
   get showImages(): boolean { return this._showImages; }
   get userMessages(): Array<{ id: string; text: string; timestamp?: number }> { return this._userMessages; }
 
-  /** Get available models from the model registry (for dynamic model pickers) */
-  async getAvailableModels(): Promise<Array<{ provider: string; id: string; name?: string }>> {
+  /** Get available models from the model registry (for dynamic model pickers). */
+  async getAvailableModels(): Promise<Array<{ provider: string; id: string; name?: string; cost?: { input: number; output: number }; contextWindow?: number }>> {
     if (!this.modelRegistry) { return []; }
     try {
       const available = await this.modelRegistry.getAvailable();
-      return available.map((m: any) => ({ provider: m.provider, id: m.id, name: m.name }));
+      return available.map((m: any) => ({
+        provider: m.provider,
+        id: m.id,
+        name: m.name,
+        cost: m.cost ? { input: m.cost.input, output: m.cost.output } : undefined,
+        contextWindow: m.contextWindow ?? undefined,
+      }));
     } catch {
       return [];
     }
+  }
+
+  /** Format model specs (pricing + context window) for QuickPick detail. Returns empty string if no data. */
+  static formatModelDetail(cost?: { input: number; output: number }, contextWindow?: number): string {
+    const parts: string[] = [];
+    if (cost) {
+      parts.push(`$${cost.input}/$${cost.output} per M tokens`);
+    }
+    if (contextWindow) {
+      parts.push(`${Math.round(contextWindow / 1000)}K context`);
+    }
+    return parts.join(" · ");
+  }
+
+  /** Open a QuickPick to choose a model, set it on this session, and optionally save as default. */
+  async pickModel(): Promise<boolean> {
+    interface ModelItem { label: string; provider: string; modelId: string; cost?: { input: number; output: number }; contextWindow?: number }
+    let models: ModelItem[] = [];
+
+    try {
+      const available = await this.getAvailableModels();
+      if (available.length > 0) {
+        models = available.map((m) => ({
+          label: m.name || m.id,
+          provider: m.provider,
+          modelId: m.id,
+          cost: m.cost,
+          contextWindow: m.contextWindow,
+        }));
+      }
+    } catch (e: any) {
+      piWarn(`pickModel: getAvailableModels failed (${e.message}), using static fallback`);
+    }
+
+    // Fallback: static list of common models (no pricing — only SDK-reported pricing is shown)
+    if (models.length === 0) {
+      models = [
+        { label: "Claude Sonnet 4.5", provider: "anthropic", modelId: "claude-sonnet-4-5" },
+        { label: "Claude Haiku 4.5", provider: "anthropic", modelId: "claude-haiku-4-5" },
+        { label: "Claude Opus 4.5", provider: "anthropic", modelId: "claude-opus-4-5" },
+        { label: "GPT 4o", provider: "openai", modelId: "gpt-4o" },
+        { label: "Gemini 2.5 Pro", provider: "google", modelId: "gemini-2.5-pro" },
+        { label: "DeepSeek V3", provider: "deepseek", modelId: "deepseek-chat" },
+      ];
+    }
+
+    const currentId = this.model?.id;
+    const defModel = this.getDefaultModel();
+    const items = models.map((m) => {
+      const isDefault = defModel && m.provider === defModel.provider && m.modelId === defModel.id;
+      return {
+        label: `${m.label}${m.modelId === currentId ? " $(check)" : ""}${isDefault ? " \u2605" : ""}`,
+        description: m.provider,
+        detail: PiService.formatModelDetail(m.cost, m.contextWindow),
+        provider: m.provider,
+        modelId: m.modelId,
+        isDefault,
+      };
+    });
+
+    const picked = await vscode.window.showQuickPick(items, { placeHolder: "Select model (\u2605 = default)", matchOnDetail: true });
+    if (!picked) { return false; }
+
+    await this.setModel(picked.provider, picked.modelId);
+
+    // Offer to save as default if not already
+    if (!picked.isDefault) {
+      const save = await vscode.window.showQuickPick(
+        [{ label: "\u2605 Save as default", description: "Use this model for future sessions" }],
+        { placeHolder: `Use as default?` },
+      );
+      if (save) { this.saveDefaultModel(); }
+    }
+
+    return true;
+  }
+
+  /** Open a QuickPick to choose a thinking level, set it on this session, and optionally save as default. */
+  async pickThinkingLevel(): Promise<boolean> {
+    const levels = [
+      { label: "off", description: "No thinking" },
+      { label: "minimal", description: "Minimal thinking" },
+      { label: "low", description: "Brief thinking" },
+      { label: "medium", description: "Balanced thinking" },
+      { label: "high", description: "Extended thinking" },
+      { label: "xhigh", description: "Maximum thinking" },
+    ];
+    const current = this.thinkingLevel;
+    const defLevel = this.getDefaultThinking();
+    const items = levels.map((l) => {
+      const isDefault = l.label === defLevel;
+      return {
+        label: `${l.label === current ? "$(check) " : ""}${l.label}${isDefault ? " \u2605" : ""}`,
+        description: l.description,
+        level: l.label,
+        isDefault,
+      };
+    });
+
+    const picked = await vscode.window.showQuickPick(items, { placeHolder: "Select thinking level (\u2605 = default)" });
+    if (!picked) { return false; }
+
+    await this.setThinkingLevel(picked.level);
+
+    // Offer to save as default if not already
+    if (!picked.isDefault) {
+      const save = await vscode.window.showQuickPick(
+        [{ label: "\u2605 Save as default", description: "Use this thinking level for future sessions" }],
+        { placeHolder: `Use "${picked.level}" thinking as the default?` },
+      );
+      if (save) { this.saveDefaultThinking(); }
+    }
+
+    return true;
   }
 
   /** Get scoped models from the session */

--- a/src/webview-panel.ts
+++ b/src/webview-panel.ts
@@ -1826,98 +1826,12 @@ export class PiWebviewPanel {
 
   /** Open VS Code quick pick to pick a model for the current session */
   private async triggerModelPicker() {
-    const ps = this.piService;
-    let modelItems: Array<{ label: string; description: string; provider: string; modelId: string }> = [];
-
-    // Use the PiService's getAvailableModels for dynamic registry discovery
-    try {
-      const available = await ps.getAvailableModels();
-      if (available.length > 0) {
-        modelItems = available.map((m) => ({
-          label: m.name || m.id,
-          description: m.provider,
-          provider: m.provider,
-          modelId: m.id,
-        }));
-      }
-    } catch (e: any) { console.warn(`[pi-gui] getAvailableModels failed, using static fallback: ${e.message}`); }
-
-    // Fallback: static list of common models
-    if (modelItems.length === 0) {
-      const fallbackModels = [
-        { label: "Claude Sonnet 4.5", description: "anthropic", provider: "anthropic", modelId: "claude-sonnet-4-5" },
-        { label: "Claude Haiku 4.5", description: "anthropic", provider: "anthropic", modelId: "claude-haiku-4-5" },
-        { label: "Claude Opus 4.5", description: "anthropic", provider: "anthropic", modelId: "claude-opus-4-5" },
-        { label: "GPT 4o", description: "openai", provider: "openai", modelId: "gpt-4o" },
-        { label: "Gemini 2.5 Pro", description: "google", provider: "google", modelId: "gemini-2.5-pro" },
-        { label: "DeepSeek V3", description: "deepseek", provider: "deepseek", modelId: "deepseek-chat" },
-      ];
-      modelItems = fallbackModels;
-    }
-
-    const currentId = ps.model?.id;
-    const defModel = ps.getDefaultModel();
-    const items = modelItems.map((m) => {
-      const isDefault = defModel && m.provider === defModel.provider && m.modelId === defModel.id;
-      const isCurrent = m.modelId === currentId;
-      return {
-        label: `${m.label}${isDefault ? " \u2605" : ""}${isCurrent ? " $(check)" : ""}`,
-        description: m.description || m.provider,
-        provider: m.provider,
-        modelId: m.modelId,
-        isDefault,
-      };
-    });
-
-    const picked = await vscode.window.showQuickPick(items, { placeHolder: "Select model (\u2605 = default)" });
-    if (!picked) { return; }
-
-    await ps.setModel(picked.provider, picked.modelId);
-
-    // Offer to save as default if not already
-    if (!picked.isDefault) {
-      const save = await vscode.window.showQuickPick(
-        [{ label: "\u2605 Save as default", description: "Use this model for future sessions" }],
-        { placeHolder: `Use ${picked.label.replace(/ \u2605| \$\(check\)/g, "")} as the default?` },
-      );
-      if (save) { ps.saveDefaultModel(); }
-    }
+    await this.piService.pickModel();
   }
 
   /** Open VS Code quick pick to pick thinking level */
   private async triggerThinkingPicker() {
-    const ps = this.piService;
-    const levels = [
-      { label: "off", description: "No thinking" },
-      { label: "minimal", description: "Minimal thinking" },
-      { label: "low", description: "Brief thinking" },
-      { label: "medium", description: "Balanced thinking" },
-      { label: "high", description: "Extended thinking" },
-      { label: "xhigh", description: "Maximum thinking" },
-    ];
-    const current = ps.thinkingLevel;
-    const defLevel = ps.getDefaultThinking();
-    const items = levels.map((l) => {
-      const isDefault = l.label === defLevel;
-      return {
-        label: `${l.label === current ? "$(check) " : ""}${l.label}${isDefault ? " \u2605" : ""}`,
-        description: l.description,
-        level: l.label,
-        isDefault,
-      };
-    });
-    const picked = await vscode.window.showQuickPick(items, { placeHolder: "Select thinking level (\u2605 = default)" });
-    if (!picked) { return; }
-    await ps.setThinkingLevel(picked.level);
-
-    // Offer to save as default if not already
-    if (!picked.isDefault) {
-      const save = await vscode.window.showQuickPick(
-        [{ label: "\u2605 Save as default", description: "Use this thinking level for future sessions" }],
-        { placeHolder: `Use "${picked.level}" thinking as the default?` },
-      );
-      if (save) { ps.saveDefaultThinking(); }
-    }
+    await this.piService.pickThinkingLevel();
   }
 
   /** Open VS Code quick pick to set context budget */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,6 @@
     "strict": true,
     "skipLibCheck": true,
     "moduleResolution": "Node16"
-  }
+  },
+  "exclude": ["agent-wiki"]
 }


### PR DESCRIPTION
Best effort to read available model pricing from the Pi SDK :)

For instance, I get 
<img width="1434" height="304" alt="image" src="https://github.com/user-attachments/assets/3f48c70d-edf1-4451-9c13-95f1ff5e2be4" />

This reflects what I can find on the respective websites, but it doesn't reflect that my current DeepSeek tokens are being billed at 75% discount (they have a sale on at the moment).