### PR TITLE
Use universal SDK path resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [0.0.55]
+
+### Fixed
+- SDK resolution now scans `$PATH` instead of relying on hardcoded candidate paths. Fixes SDK-not-found on systems with custom npm prefix locations.
+
 ## [0.0.54]
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Jack Noppé",
   "displayName": "Pi Code Gui",
   "description": "Native VS Code editor experience for Pi coding agent",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "license": "MIT",
   "sponsor": {
     "url": "https://github.com/sponsors/NimbleTronAI"

--- a/src/pi-service.ts
+++ b/src/pi-service.ts
@@ -71,38 +71,52 @@ type EventListener = (event: PiServiceEvent) => void;
 // ── SDK Resolution ───────────────────────────────────────
 
 export function resolvePiPackagePath(): string {
-  const candidates: string[] = [];
+  const pkgSuffix = path.join("node_modules", "@earendil-works", "pi-coding-agent");
+  const candidates: Set<string> = new Set();
 
-  // Project-local from pi packages (workspace install)
-  candidates.push(path.resolve(".pi/npm/node_modules/@earendil-works/pi-coding-agent"));
+  // 1. Project-local install
+  candidates.add(path.resolve(path.join(".pi", "npm", pkgSuffix)));
 
-  // Global npm / yarn / pnpm locations
-  const home = process.env.HOME || process.env.USERPROFILE || "";
-  if (home) {
-    candidates.push(
-      path.join(home, ".npm-global/lib/node_modules/@earendil-works/pi-coding-agent"),
-      path.join(home, ".local/lib/node_modules/@earendil-works/pi-coding-agent"),
-    );
+  // 2. Universal PATH scan — derive npm global prefixes from $PATH entries
+  const pathEnv = process.env.PATH || "";
+  const separator = process.platform === "win32" ? ";" : ":";
+  const seenPrefixes = new Set<string>();
+  for (const binDir of pathEnv.split(separator)) {
+    if (!binDir) { continue; }
+    let normBin = path.normalize(binDir);
+    if (normBin.endsWith(path.sep)) { normBin = normBin.slice(0, -1); }
+    const prefix = path.dirname(normBin);
+    if (seenPrefixes.has(normBin)) { continue; }
+    seenPrefixes.add(normBin);
+    candidates.add(path.join(prefix, "lib", pkgSuffix));
+    if (process.platform === "win32") {
+      candidates.add(path.join(prefix, pkgSuffix));
+    }
   }
 
-  // nvm
+
+  // 3. Windows AppData (npm default on Windows)
+  const appData = process.env.APPDATA || "";
+  if (appData) {
+    candidates.add(path.join(appData, "npm", pkgSuffix));
+  }
+
+
+  // 4. Legacy hardcoded fallbacks (for GUI-launched VS Code with incomplete $PATH)
+  const home = process.env.HOME || process.env.USERPROFILE || "";
+  if (home) {
+    candidates.add(path.join(home, ".npm-global", "lib", pkgSuffix));
+    candidates.add(path.join(home, ".local", "lib", pkgSuffix));
+  }
   if (process.env.NVM_DIR) {
     try {
       const versionsDir = path.join(process.env.NVM_DIR, "versions", "node");
       if (fs.existsSync(versionsDir)) {
         for (const version of fs.readdirSync(versionsDir)) {
-          candidates.push(
-            path.join(versionsDir, version, "lib", "node_modules", "@earendil-works", "pi-coding-agent"),
-          );
+          candidates.add(path.join(versionsDir, version, "lib", pkgSuffix));
         }
       }
     } catch (e: unknown) { piWarn(`Non-critical failure (ignored): ${e instanceof Error ? e.message : String(e)}`); }
-  }
-
-  // Windows %APPDATA%\npm
-  const appData = process.env.APPDATA || "";
-  if (appData) {
-    candidates.push(path.join(appData, "npm", "node_modules", "@earendil-works", "pi-coding-agent"));
   }
 
   for (const candidate of candidates) {


### PR DESCRIPTION
resolvePiPackagePath() only searched nvm, ~/.npm-global, ~/.local paths. Node installed via mise, fnm, volta, or custom prefix was not found.

Scan $PATH entries instead: derive <prefix>/lib/node_modules/<pkg> from each <prefix>/bin in PATH. Works for any node version manager.

- Skip empty PATH entries (prevents junk candidates from ::)
- Add Windows candidate without lib/ segment (npm layout differs)
- Keep legacy fallbacks for GUI-launched VS Code with incomplete PATH
- Fix dedup key: use normBin instead of dirname to avoid false-dedup