### PR TITLE
feat: add setting to disable auto-opening Pi tab on start

### DIFF
--- a/package.json
+++ b/package.json
@@ -327,6 +327,11 @@
           "type": "string",
           "default": "",
           "description": "Custom session storage directory for session .jsonl files. Empty = use the pi SDK default (~/.pi/agent/sessions/). Equivalent to --session-dir."
+        },
+        "pi-code-gui.autoOpenOnStart": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically open the Pi chat tab when VS Code starts. When disabled, sessions initialize in the background but the tab is not revealed until you open it manually."
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -717,6 +717,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const savedPaths: string[] = ((context.workspaceState.get("pi-code-gui.openSessionPaths") as string[]) ?? [])
     .filter((p: string) => fs.existsSync(p));
   const savedActivePath: string | undefined = context.workspaceState.get("pi-code-gui.activeSessionPath") ?? undefined;
+  const autoOpen = vscode.workspace.getConfiguration("pi-code-gui").get<boolean>("autoOpenOnStart", true);
 
   if (savedPaths.length > 0) {
     // Restore session counter to avoid ID collisions.
@@ -729,7 +730,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     for (let i = 0; i < savedPaths.length; i++) {
       const sw = createSessionWindow(context);
       if (i === 0) { setActiveSession(sw); }
-      void sw.webviewPanel.show();
+      if (autoOpen) { void sw.webviewPanel.show(); }
       void initSessionInBackground(context, sw, { openPath: savedPaths[i] });
     }
     restoreActiveSession(savedActivePath);
@@ -737,7 +738,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     // No saved sessions — create one fresh session
     const sw = createSessionWindow(context);
     setActiveSession(sw);
-    void sw.webviewPanel.show();
+    if (autoOpen) { void sw.webviewPanel.show(); }
     void initSessionInBackground(context, sw, { fresh: true });
   }
 


### PR DESCRIPTION
## Summary

Adds a new VS Code setting `pi-code-gui.autoOpenOnStart` (boolean, default: `true`) that controls whether the Pi chat tab is automatically revealed when VS Code starts.

When disabled, sessions still initialize in the background but the tab stays hidden until the user opens it manually (e.g., via the "PiGui: Code Agent" command or sidebar).

## Changes

- **`package.json`** — Added `pi-code-gui.autoOpenOnStart` configuration property
- **`src/extension.ts`** — Read the setting in the Step 4 block and gate the two `webviewPanel.show()` calls (session restore + fresh session creation)

## Testing

- `pnpm run compile` passes (type-check, lint, esbuild)
- Default behavior (setting = `true`) preserves current auto-open behavior
- Setting = `false` — session initializes but tab is not revealed automatically
- Manual open via command palette still works regardless of setting