### PR TITLE
security(webview): restrict openUrl to http(s)/mailto schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [Unreleased]
+
+### Security
+- Restricted the `openUrl` webview handler to `http(s)`/`mailto` schemes so a crafted webview message can't ask the host to open an unexpected URI (e.g. `file:` or a custom-protocol handler).
+
 ## [0.0.55]
 
 ### Fixed

--- a/src/webview-panel.ts
+++ b/src/webview-panel.ts
@@ -163,9 +163,19 @@ export class PiWebviewPanel {
             void this.triggerEffortPicker();
             break;
 
-          case "openUrl":
-            vscode.env.openExternal(vscode.Uri.parse(message.url));
+          case "openUrl": {
+            // Only allow external navigation for http(s)/mailto URLs coming
+            // from the webview; reject other schemes (javascript:, file:,
+            // data:, …) that could be abused if a message were crafted to
+            // trigger openExternal with an unexpected URI.
+            const url = vscode.Uri.parse(message.url);
+            if (url.scheme === "http" || url.scheme === "https" || url.scheme === "mailto") {
+              vscode.env.openExternal(url);
+            } else {
+              console.warn(`[pi-gui] Refusing openExternal for disallowed URL scheme: ${url.scheme}`);
+            }
             break;
+          }
 
           case "openFile":
             vscode.window.showTextDocument(vscode.Uri.file(message.path));


### PR DESCRIPTION
## Summary

The `openUrl` webview→host handler in `src/webview-panel.ts` passed any `message.url` straight to `vscode.env.openExternal(vscode.Uri.parse(message.url))` with no scheme check. `openExternal` is user-gated (a click), but a crafted webview message could ask the host to open an unexpected URI (e.g. `file:` or a custom-protocol handler registered on the user's machine).

## Change

Only allow `http`, `https`, and `mailto` — the schemes that make sense for opening something in the user's browser/mailer and that match the schemes the rendered-chat link sanitizer (`safeLinkHref`, proposed in #65) already permits. Anything else is logged and ignored.

## Validation

- `pnpm run compile` passes (type-check + lint + esbuild build).
- CHANGELOG entry added under `[Unreleased]` → `### Security`.

## Out of scope (noted, not included)

The adjacent `openFile` handler opens an arbitrary path with no workspace-containment check — separate concern, left for a follow-up to keep this PR focused.

---

Prepared with the assistance of the Pi coding agent; reviewed and submitted by me.