### PR TITLE
docs: correct api-key settings persistence claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [Unreleased]
+
+### Changed
+- Corrected the README and `package.json` setting descriptions: the `anthropicApiKey`/`openaiApiKey` settings are stored in plaintext in VS Code settings (previously documented as "not persisted to disk"). Recommend the env vars or `/login` instead.
+
 ## [0.0.55]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -214,8 +214,8 @@ Pi Code Gui loads the `@earendil-works/pi-coding-agent` SDK at runtime from your
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `pi-code-gui.promptToInstall` | boolean | `true` | Prompt to install Pi if not found |
-| `pi-code-gui.anthropicApiKey` | string | `""` | Runtime Anthropic API key (overrides env var, not persisted to disk) |
-| `pi-code-gui.openaiApiKey` | string | `""` | Runtime OpenAI API key (overrides env var, not persisted to disk) |
+| `pi-code-gui.anthropicApiKey` | string | `""` | Runtime Anthropic API key (overrides `ANTHROPIC_API_KEY` env var). Stored in plaintext in VS Code settings — prefer the env var or `/login` |
+| `pi-code-gui.openaiApiKey` | string | `""` | Runtime OpenAI API key (overrides `OPENAI_API_KEY` env var). Stored in plaintext in VS Code settings — prefer the env var or `/login` |
 | `pi-code-gui.systemPromptAppend` | string | `""` | Additional instructions appended to the system prompt |
 | `pi-code-gui.enableSkills` | boolean | `true` | Load project and global pi skills |
 | `pi-code-gui.enableContextFiles` | boolean | `true` | Inject project context files |

--- a/agent-wiki/bootstrap/AGENTS.md
+++ b/agent-wiki/bootstrap/AGENTS.md
@@ -69,7 +69,9 @@ bypass VS Code's buffer tracking and cause dirty-state mismatches.
   The `.pi/` directory is gitignored.
 - API keys: Pi SDK's `AuthStorage` (system keychain via keytar) or runtime
   override from `pi-code-gui.anthropicApiKey` / `pi-code-gui.openaiApiKey`.
-  Never written to disk as plaintext.
+  `AuthStorage` keys are not written to disk as plaintext, but the two settings
+  above, if set, are stored in plaintext in VS Code's settings.json — prefer
+  the `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` env vars or `/login`.
 - Open session paths: `context.workspaceState` (VS Code workspace storage) —
   per-workspace, survives window reloads.
 

--- a/agent-wiki/log.md
+++ b/agent-wiki/log.md
@@ -5,6 +5,8 @@ starts with `## [YYYY-MM-DD] <action> | <description>`. Actions:
 `ingest` (new page), `update` (existing page changed), `lint` (quality
 pass performed), `archive` (page moved to archive).
 
+## [2026-07-24] update | Bootstrap (AGENTS.md) — corrected API-key persistence claim: `anthropicApiKey`/`openaiApiKey` settings are plaintext in settings.json (was "never written to disk as plaintext")
+
 ## [2026-05-27] lint | Full wiki + README audit — bridge-tools (16 tools, not 17; dedup table row), syntax-highlighting (15 languages, +yaml/sql/diff), tree-views (progressive load, entry caching, state-change refresh), event-translation (turn-end, message_update error, user message_end), streaming-pipeline (progressive replay), README (16 tools)
 ## [2026-05-26] update | Bridge Tools, PiService — added `/tools` runtime picker with persistence, replaced static `pi-code-gui.tools` allowlist
 ## [2026-05-25] archive | Architecture — Multi-Backend Architecture → `archive/multi-backend.md` (rejected: incompatible extension/UI model)

--- a/package.json
+++ b/package.json
@@ -268,12 +268,12 @@
         "pi-code-gui.anthropicApiKey": {
           "type": "string",
           "default": "",
-          "description": "Anthropic API key for Claude models (overrides ANTHROPIC_API_KEY env var at runtime)"
+          "description": "Anthropic API key for Claude models (overrides ANTHROPIC_API_KEY env var at runtime). Stored in plaintext in VS Code settings; prefer the env var or /login."
         },
         "pi-code-gui.openaiApiKey": {
           "type": "string",
           "default": "",
-          "description": "OpenAI API key for GPT models (overrides OPENAI_API_KEY env var at runtime)"
+          "description": "OpenAI API key for GPT models (overrides OPENAI_API_KEY env var at runtime). Stored in plaintext in VS Code settings; prefer the env var or /login."
         },
         "pi-code-gui.systemPromptAppend": {
           "type": "string",

--- a/src/pi-service.ts
+++ b/src/pi-service.ts
@@ -520,7 +520,7 @@ export class PiService {
     try {
       this.authStorage = SDK.AuthStorage.create();
 
-      // Runtime API key override from VS Code secrets or env
+      // Runtime API key override from VS Code configuration (plaintext) or env
       const config = vscode.workspace.getConfiguration("pi-code-gui");
       const anthropicKey = config.get<string>("anthropicApiKey");
       if (anthropicKey) {


### PR DESCRIPTION
## Summary

The README stated that the `anthropicApiKey` / `openaiApiKey` settings are "not persisted to disk". They are ordinary VS Code string settings, so any value entered is persisted in plaintext to the user's (or workspace) `settings.json`. This corrects the documentation and points users toward safer alternatives.

## Changes

- `README.md` settings table: corrected the two rows to state the keys are stored in plaintext and to prefer the env vars or `/login`.
- `package.json` `contributes.configuration` descriptions for both settings: added the same plaintext note (these show in the VS Code Settings UI).
- `src/pi-service.ts`: fixed a misleading comment that referred to these as "VS Code secrets" — they are read from configuration (plaintext), not from VS Code SecretStorage.
- `agent-wiki/bootstrap/AGENTS.md`: corrected the matching "Never written to disk as plaintext" claim, distinguishing `AuthStorage` (keychain, not plaintext) from the two settings (plaintext in `settings.json`).
- `agent-wiki/log.md`: appended a wiki log entry.
- `CHANGELOG.md`: `[Unreleased]` → `### Changed` entry.

## Validation

- `pnpm run compile` passes (type-check + lint + esbuild build). (Documentation-only; no runtime change.)

---

Prepared with the assistance of the Pi coding agent; reviewed and submitted by me.