### PR TITLE
Dispatch the publish on the tag, and stop claiming an approval gate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,12 @@
-# Triggered when a GitHub Release is published.
-# The publish jobs run inside the `marketplace` environment, which gates them
-# behind required reviewers and branch policy.
+# Triggered when a GitHub Release is published, or dispatched by release.yml.
+#
+# The publish jobs run inside the `marketplace` environment. Its only protection rule is a
+# deployment branch policy admitting the single TAG pattern `v0.*` — there are NO required
+# reviewers, so reaching these jobs means shipping, with nothing to approve. Two consequences
+# worth knowing before you edit this file:
+#   - This workflow must be reached on a tag ref. A run on a branch ref is rejected before any
+#     step executes (~2s, no runner), which looks like a build failure and is not one.
+#   - Nothing else stands between a merge to main and a live release.
 
 name: Publish the VS Code Extension
 
@@ -35,8 +41,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          # On workflow_dispatch the default ref is the branch, which would package the wrong
-          # commit; on `release: published` this is empty and checkout keeps its default.
+          # Pin the packaged commit to the tag input rather than trusting the dispatched ref:
+          # a hand-run from the Actions UI can select any ref, and packaging something other
+          # than the tag being published is silent and hard to spot. On `release: published`
+          # this is empty and checkout keeps its default.
           ref: ${{ inputs.tag || '' }}
       - uses: actions/setup-node@v7
         with:
@@ -64,8 +72,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          # On workflow_dispatch the default ref is the branch, which would package the wrong
-          # commit; on `release: published` this is empty and checkout keeps its default.
+          # Pin the packaged commit to the tag input rather than trusting the dispatched ref:
+          # a hand-run from the Actions UI can select any ref, and packaging something other
+          # than the tag being published is silent and hard to spot. On `release: published`
+          # this is empty and checkout keeps its default.
           ref: ${{ inputs.tag || '' }}
       - uses: actions/setup-node@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,14 @@ name: Tag and release on version bump
 # and a GitHub Release with auto-generated notes.
 #
 # Publishing to the VS Code Marketplace / Open VSX is NOT done here — publish.yml
-# already does that on `release: published` (gated by the `marketplace`
-# environment's required reviewers). So this release will QUEUE that publish for
-# your approval; it won't ship anything on its own.
+# does that, and the step below dispatches it.
+#
+# Be clear about what gates that publish: the `marketplace` environment's ONLY
+# protection rule is a deployment branch policy admitting the single TAG pattern
+# `v0.*`. There are no required reviewers and no wait timer, so nothing pauses
+# for human approval — a successful run of this workflow SHIPS. Earlier comments
+# here claimed an approval gate that does not exist; if you want one, add
+# required reviewers to the environment, don't rely on this text.
 on:
   push:
     branches: [main]
@@ -60,6 +65,11 @@ jobs:
           # GITHUB_TOKEN, and GitHub does not start workflow runs from that token — so
           # publish.yml would never fire on its own. v0.1.4 was tagged and released and simply
           # never published, with nothing queued and no failure to notice. Dispatching by hand
-          # closes the chain without introducing a PAT. The publish still runs inside the
-          # `marketplace` environment, so its required reviewers gate it exactly as before.
-          gh workflow run publish.yml --ref main -f tag="$V"
+          # closes the chain without introducing a PAT.
+          #
+          # Dispatch on the TAG, not on main. The `marketplace` environment admits only tag
+          # refs matching `v0.*`, so a run dispatched with `--ref main` is rejected outright:
+          # both jobs fail in ~2s with no runner and no steps, which reads as a build failure
+          # and is not one. That is exactly how v0.1.6 failed. The tag also pins the workflow
+          # definition to the released commit, so a publish reflects what was tagged.
+          gh workflow run publish.yml --ref "$V" -f tag="$V"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 # Change Log
 
+## [0.1.7]
+
+Carries the Windows fix below, which 0.1.6 tagged but never shipped.
+
+### Fixed
+- **Automated releases were rejected before they could publish.** The `marketplace` environment
+  admits only tag refs matching `v0.*`, and release.yml dispatched the publish with `--ref main`,
+  so both jobs failed in about two seconds with no runner assigned and no steps run — which reads
+  as a build failure and is not one. That stranded v0.1.6. The dispatch now targets the tag it
+  just created.
+
+  Corrects the surrounding comments as well: they described the publish as gated behind the
+  environment's required reviewers and said a release "won't ship anything on its own". That
+  gate does not exist — the environment has no required reviewers and no wait timer, so a
+  merge to main now goes live unattended.
+
 ## [0.1.6]
+
+Tagged and released, but never reached either marketplace — see 0.1.7. Nothing to install here.
 
 ### Fixed
 - **The TypeScript runtime could not start on Windows.** SDK modules are loaded by absolute path, and Node's ESM loader reads a Windows path's drive letter as a URL scheme (`Received protocol 'c:'`), so every session failed at startup. Paths are now converted with `pathToFileURL`. (#71)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Jack Noppé",
   "displayName": "Pi Code Gui",
   "description": "Native VS Code editor experience for Pi coding agent",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "license": "MIT",
   "sponsor": {
     "url": "https://github.com/sponsors/NimbleTronAI"


### PR DESCRIPTION
v0.1.6 was tagged and released, and its publish failed in about two seconds with no runner assigned and no steps executed. That reads as a build failure and is not one: the `marketplace` environment's only protection rule is a deployment branch policy admitting the single TAG pattern `v0.*`, and release.yml dispatched publish.yml with `--ref main`. A branch ref does not match, so both jobs were rejected before they could start. Every publish that has ever succeeded, back to v0.0.41, ran on a tag ref; ours was the first on a branch.

The dispatch now targets the tag it just created. That satisfies the policy and pins the workflow definition to the released commit, so a publish reflects what was tagged rather than whatever main holds at dispatch time.

The comments were worse than wrong, because they described a safety net that is not there. release.yml said the release would "QUEUE that publish for your approval" and "won't ship anything on its own"; publish.yml said the environment gates the jobs "behind required reviewers and branch policy". The environment has no required reviewers and no wait timer — only the branch policy. Nothing pauses for a human, so a merge to main ships. Both files now say so, and point at the environment as the place to add a gate if one is wanted.

Also corrects the checkout comments, which explained the `ref:` pin in terms of the dispatch defaulting to a branch. It no longer does. The pin still earns its place: a hand-run from the Actions UI can select any ref, and packaging a commit other than the tag being published would be silent.

Cut as 0.1.7, carrying the Windows ESM fix that 0.1.6 never delivered. 561 tests, types and lint clean; both workflows parse.