### PR TITLE
Run the supply-chain scan at publish time, not only in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,6 +51,21 @@ jobs:
           node-version: '24'
       - run: corepack enable
       - run: pnpm install --frozen-lockfile
+      # Supply-chain gate: known-compromised versions, IOC filenames/strings/hashes, and install
+      # hooks outside the allowlist. CRITICAL findings exit non-zero even without --strict.
+      #
+      # This also runs in ci.yml, and that is NOT enough. ci.yml and release.yml trigger on the
+      # same push to main and run concurrently, so the publish is dispatched and can finish
+      # before CI has said anything — CI cannot gate it. Every other CI step is already covered
+      # here, because `vsce publish`/`vsce package` run `vscode:prepublish` (the full
+      # `pnpm run package` gate: cleanroom, diagram, model registry, types, lint, the unit
+      # suite, production bundles). This scan was the sole exception, which meant a compromised
+      # dependency could be installed and bundled into the .vsix unscanned. Keep it here so the
+      # publish stands on its own and the CI race stays irrelevant.
+      #
+      # Drift is advisory without --strict, and unreachable upstream sources only fail under
+      # --strict, so a flaky registry cannot block a release. Only a CRITICAL finding does.
+      - run: node scripts/check-currency.mjs
       # check:cleanroom scans with ripgrep and HARD-FAILS when it is absent — a missing rg
       # used to exit 127 and fall through to a silent PASS, so the wall reported OK on a
       # machine that could not actually scan. The runner image does not ship ripgrep.
@@ -82,6 +97,21 @@ jobs:
           node-version: '24'
       - run: corepack enable
       - run: pnpm install --frozen-lockfile
+      # Supply-chain gate: known-compromised versions, IOC filenames/strings/hashes, and install
+      # hooks outside the allowlist. CRITICAL findings exit non-zero even without --strict.
+      #
+      # This also runs in ci.yml, and that is NOT enough. ci.yml and release.yml trigger on the
+      # same push to main and run concurrently, so the publish is dispatched and can finish
+      # before CI has said anything — CI cannot gate it. Every other CI step is already covered
+      # here, because `vsce publish`/`vsce package` run `vscode:prepublish` (the full
+      # `pnpm run package` gate: cleanroom, diagram, model registry, types, lint, the unit
+      # suite, production bundles). This scan was the sole exception, which meant a compromised
+      # dependency could be installed and bundled into the .vsix unscanned. Keep it here so the
+      # publish stands on its own and the CI race stays irrelevant.
+      #
+      # Drift is advisory without --strict, and unreachable upstream sources only fail under
+      # --strict, so a flaky registry cannot block a release. Only a CRITICAL finding does.
+      - run: node scripts/check-currency.mjs
       # `vsce package` runs the `vscode:prepublish` script, i.e. the full `pnpm run package`
       # gate — which includes check:cleanroom, and that hard-fails without ripgrep. The runner
       # image does not ship it. This job needs it for exactly the same reason the marketplace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## [0.1.8]
+
+No user-facing change — a release-pipeline fix.
+
+### Security
+- **The supply-chain scan now runs before publishing, not only in CI.** `check-currency.mjs`
+  rejects known-compromised dependency versions, indicators of compromise, and install hooks
+  outside the allowlist. It ran only in ci.yml, which cannot gate a release: CI and the release
+  workflow trigger on the same push and run concurrently, so the publish is dispatched — and can
+  finish — before CI reports. In 0.1.7 the publish completed 15 seconds after CI, having never
+  waited for it. Every other CI check was already re-run at publish time via `vscode:prepublish`;
+  this scan was the only one that was not, so a compromised package could be installed and
+  bundled into the `.vsix` unscanned. Both publish jobs now run it themselves.
+
 ## [0.1.7]
 
 Carries the Windows fix below, which 0.1.6 tagged but never shipped.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Jack Noppé",
   "displayName": "Pi Code Gui",
   "description": "Native VS Code editor experience for Pi coding agent",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "license": "MIT",
   "sponsor": {
     "url": "https://github.com/sponsors/NimbleTronAI"


### PR DESCRIPTION
check-currency.mjs rejects known-compromised dependency versions, indicators of compromise, and install hooks outside the allowlist. CRITICAL findings exit non-zero even without --strict — "This is not advisory," as the script puts it. It ran in ci.yml alone, and ci.yml cannot gate a release.

ci.yml and release.yml both trigger on the same push to main. They are separate workflows, so `needs:` cannot sequence them: they start together and release.yml dispatches the publish immediately. In 0.1.7 the publish finished at 15:50:48 and CI at 15:50:33 — the publish overlapped CI almost end to end and would have shipped identically had CI gone red. Nothing was gating anything; the scan only ever protected a release by winning a race it was not entered in.

Every other CI step was already covered at publish time, because vsce runs `vscode:prepublish` — the full `pnpm run package` gate (cleanroom, diagram, model registry, types, lint, the unit suite, production bundles). This scan was the single exception, so a compromised package could be installed by the publish's own `pnpm install --frozen-lockfile` and bundled into the .vsix having never been looked at.

Both publish jobs now run it, in the same position as ci.yml. Fixing the ordering instead — a workflow_run trigger — would buy the same property for more moving parts (no paths: filter, manual head_sha handling), and would still leave the publish dependent on another workflow having run. A publish that carries its own gates does not care what else is running.

Drift stays advisory and unreachable sources still only fail under --strict, so a flaky registry cannot block a release; only a CRITICAL finding can.

Cut as 0.1.8. Scan is clean locally (2233 packages, exit 0), 561 tests pass, publish.yml parses and both jobs show the step in order.