### PR TITLE
Probe the PATH entry itself when resolving the SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [0.1.12]
+
+### Fixed
+- **Windows: the SDK went undetected when the npm prefix is itself on `PATH`.** Candidates were only ever derived from the PATH entry's *parent*, so a layout like `D:\nodejs` (packages in `D:\nodejs\node_modules`) had none — the extension reported "SDK is not installed" while `pi --version` worked in a shell. Also affects nvm-windows. The PATH entry itself is now probed, on every platform. (#81)
+
 ## [0.1.11]
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Jack Noppé",
   "displayName": "Pi Code Gui",
   "description": "Native VS Code editor experience for Pi coding agent",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "license": "MIT",
   "sponsor": {
     "url": "https://github.com/sponsors/NimbleTronAI"

--- a/src/pi-package-path.ts
+++ b/src/pi-package-path.ts
@@ -49,6 +49,20 @@ export function buildPiPackageCandidates(i: PiPackageCandidateInputs): string[] 
     const prefix = path.dirname(normBin);
     candidates.add(path.join(prefix, "lib", PKG_SUFFIX));
     if (isWin) { candidates.add(path.join(prefix, PKG_SUFFIX)); }
+    // The PATH entry ITSELF, not just its parent. Every candidate above assumes the npm prefix
+    // is dirname(<PATH entry>) — true for `<prefix>/bin` on POSIX and `<prefix>/npm` on Windows,
+    // and false whenever the prefix directory is on PATH directly and holds node_modules beside
+    // its binaries. Node installed to D:\nodejs (npm prefix = D:\nodejs, packages in
+    // D:\nodejs\node_modules) then had NO candidate at all: dirname gives D:\, so we probed
+    // D:\lib\node_modules and D:\node_modules and gave up, reporting "SDK is not installed"
+    // while `pi --version` worked in a shell. nvm-windows puts the active version directory on
+    // PATH the same way. (#81)
+    //
+    // Added on every platform, not just win32 as reported: the layout is not Windows-specific,
+    // an unrelated candidate costs one stat of a directory that does not exist, and gating it on
+    // the platform would leave the identical POSIX prefix-on-PATH case to be re-reported later.
+    // Added LAST in the loop so it cannot outrank an existing working resolution.
+    candidates.add(path.join(normBin, PKG_SUFFIX));
   }
 
   // 3. Windows AppData (npm default on Windows)

--- a/src/test/unit/pi-package-path.test.ts
+++ b/src/test/unit/pi-package-path.test.ts
@@ -79,3 +79,31 @@ test("pickPiPackagePath: a throwing probe skips that candidate, not the whole sc
   });
   assert.equal(found, "/y");
 });
+
+// ── #81: the npm prefix IS the PATH entry ───────────────────────────
+test("buildPiPackageCandidates: a PATH entry that is itself the npm prefix resolves (#81)", () => {
+  // Node installed to D:\nodejs with npm prefix = D:\nodejs puts packages in
+  // D:\nodejs\node_modules, beside node.exe rather than under a parent. Deriving only from
+  // dirname() probed D:\lib\node_modules and D:\node_modules and gave up — the extension
+  // reported "SDK is not installed" while `pi --version` worked in a shell. nvm-windows lays
+  // the active version out the same way.
+  const c = buildPiPackageCandidates({ platform: "win32", pathEnv: "D:\\nodejs" });
+  assert.ok(c.includes(path.join("D:\\nodejs", SUFFIX)), "the PATH entry itself is a candidate");
+});
+
+test("buildPiPackageCandidates: prefix-on-PATH also resolves on POSIX", () => {
+  // Deliberately not gated on win32: the layout is not Windows-specific, and a candidate that
+  // does not exist costs one stat.
+  const c = buildPiPackageCandidates({ platform: "linux", pathEnv: "/opt/node" });
+  assert.ok(c.includes(path.join("/opt/node", SUFFIX)));
+});
+
+test("buildPiPackageCandidates: the new candidate never outranks an existing resolution", () => {
+  // Ordering is load-bearing here, so assert it rather than trusting insertion order: the
+  // conventional <prefix>/lib layout must still be probed before the PATH entry itself.
+  const c = buildPiPackageCandidates({ platform: "linux", pathEnv: "/usr/local/bin" });
+  const conventional = c.indexOf(path.join("/usr/local", "lib", SUFFIX));
+  const pathEntry = c.indexOf(path.join("/usr/local/bin", SUFFIX));
+  assert.ok(conventional !== -1 && pathEntry !== -1);
+  assert.ok(conventional < pathEntry, "conventional prefix layout still wins");
+});


### PR DESCRIPTION
Every candidate directory was derived from the PATH entry's PARENT: `<dirname>/lib/node_modules/...` and, on win32, `<dirname>/node_modules/...`. That assumes the npm prefix sits one level above the binaries — true for `<prefix>/bin` on POSIX and `<prefix>/npm` on Windows, false whenever the prefix directory is on PATH itself with node_modules beside its binaries.

Node installed to D:\nodejs (npm prefix D:\nodejs, packages in D:\nodejs\node_modules) therefore had NO candidate at all — dirname gives D:\, so we probed D:\lib\node_modules and D:\node_modules and gave up. The user sees "Pi coding agent SDK is not installed" while `pi --version` answers fine in a shell, which sends them to inspect their npm install rather than the extension. nvm-windows lays the active version out the same way, so this is not exotic.

Probing the PATH entry itself fixes it. Done on EVERY platform rather than the win32 branch the report suggested: the layout is not Windows-specific, a candidate that does not exist costs one stat, and gating on platform leaves the identical POSIX case to be re-reported later. Added last within the loop so it cannot outrank a working resolution — asserted by a test rather than left to insertion order.

Cut as 0.1.12. Reported by @glenn2wang (#81).

580 tests (3 new), types and lint clean.