### PR TITLE
Make the catalog currency check advisory, fatal only at publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,13 +70,19 @@ jobs:
       # used to exit 127 and fall through to a silent PASS, so the wall reported OK on a
       # machine that could not actually scan. The runner image does not ship ripgrep.
       - run: sudo apt-get update && sudo apt-get install -y ripgrep
+      # A publish is the one place a stale catalog reaches users, so the currency check is fatal
+      # here and advisory everywhere else. See scripts/check-model-registry.mjs.
       - run: pnpm run pretest
+        env:
+          PI_REGISTRY_CURRENCY_STRICT: "1"
       - uses: azure/login@v3
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           allow-no-subscriptions: true
       - run: pnpm exec vsce publish --no-dependencies --no-yarn --skip-duplicate --azure-credential
+        env:
+          PI_REGISTRY_CURRENCY_STRICT: "1"
 
   publish-ovsx:
     name: Publish to Open VSX
@@ -118,6 +124,8 @@ jobs:
       # job does; omitting it here is what failed the v0.1.1 Open VSX publish.
       - run: sudo apt-get update && sudo apt-get install -y ripgrep
       - run: pnpm exec vsce package --no-dependencies -o pi-code-gui.vsix
+        env:
+          PI_REGISTRY_CURRENCY_STRICT: "1"
       # The token goes through the ENVIRONMENT, not argv: process arguments are world-readable
       # via /proc/<pid>/cmdline on the runner, and appear in error output. ovsx reads OVSX_PAT.
       # `create-namespace` legitimately fails once the namespace exists, so tolerate ONLY that —

--- a/scripts/check-model-registry.mjs
+++ b/scripts/check-model-registry.mjs
@@ -44,7 +44,25 @@ if (stamped !== installed) {
 //
 // Network-tolerant by design: a build must not fail because npm is unreachable. Unreachable is a
 // warning; a definite answer showing drift is fatal.
+// Fatal ONLY where a stale catalog actually reaches users: the publish jobs set
+// PI_REGISTRY_CURRENCY_STRICT=1. Everywhere else this warns.
+//
+// It was fatal everywhere, and that was wrong in a way worth naming. The check depends on what
+// UPSTREAM publishes, so a green pipeline turns red with no change to this repo — it took out an
+// unrelated Dependabot PR (@types/node, eslint, zod) the day pi-ai 0.85.1 shipped. Three things
+// follow from that:
+//
+//   - The blast radius was wrong. A stale catalog is a defect in the artifact we SHIP, not a
+//     reason to block a lint-config bump.
+//   - It blocks the people who would fix it, by failing every branch at once.
+//   - It would have been routed around. The first time this red-walls a release day, someone
+//     sets PI_SKIP_REGISTRY_CURRENCY=1 in CI permanently and the signal is gone for good — worse
+//     than the warning it replaced.
+//
+// The consistency check above stays fatal everywhere: it is deterministic, caused only by our
+// own commits (a pi-ai bump without regenerating), and fixable by the person who tripped it.
 const SKIP = process.env.PI_SKIP_REGISTRY_CURRENCY === "1";
+const STRICT = process.env.PI_REGISTRY_CURRENCY_STRICT === "1";
 
 function cmpSemver(a, b) {
   const pa = String(a).split(".").map(Number), pb = String(b).split(".").map(Number);
@@ -74,13 +92,16 @@ if (SKIP) {
     console.log(`model-registry.generated.json is in sync with pi-ai ${installed}`);
     console.log("  note: could not reach npm to check whether that is the current release");
   } else if (cmpSemver(installed, latest) < 0) {
-    console.error(`\n  model catalog is STALE: pi-ai ${installed} is installed, ${latest} is published.`);
+    console.error(`\n  ${STRICT ? "model catalog is STALE" : "WARNING: model catalog is behind"}: pi-ai ${installed} is installed, ${latest} is published.`);
     console.error("  The catalog carries model PRICING and availability, so a stale one quotes rates");
     console.error("  that may no longer exist and hides models you can use.\n");
     console.error("  Fix:  pnpm add -D @earendil-works/pi-ai@latest && npm run gen:model-registry");
     console.error("  Then commit package.json, the lockfile and src/model-registry.generated.json.\n");
-    console.error("  Deliberately pinning? Set PI_SKIP_REGISTRY_CURRENCY=1 for this build.\n");
-    process.exit(1);
+    if (STRICT) {
+      console.error("  Deliberately pinning? Set PI_SKIP_REGISTRY_CURRENCY=1 for this build.\n");
+      process.exit(1);
+    }
+    console.error("  Not failing this build — only a publish refuses to ship a stale catalog.\n");
   } else {
     console.log(`model-registry.generated.json is in sync with pi-ai ${installed} (current)`);
   }


### PR DESCRIPTION
PR #89 — a Dependabot bump of @types/node, eslint, typescript-eslint and zod — failed on `pnpm run package`. Nothing in it touches the model catalog. It failed because pi-ai 0.85.1 published while we sit on 0.84.4, and I had made that a hard error on every build.

That was the wrong blast radius, and the failure mode is worse than the bug it guards:

  - The check depends on what UPSTREAM publishes, so a green pipeline turns red with no change to this repo. Every open PR breaks at once, on someone else's release schedule.
  - It blocks the people who would fix it. An urgent fix cannot merge while the catalog is behind, and the catalog being behind has nothing to do with it.
  - It would have been routed around within a week. The first time this red-walls a release day, someone sets PI_SKIP_REGISTRY_CURRENCY=1 in CI permanently and the signal is gone for good — strictly worse than the warning it replaced.

The split is now by determinism, not by severity:

  CONSISTENCY (registry vs installed pi-ai) stays fatal everywhere. It is caused only by our own commits — a pi-ai bump without regenerating — and the person who tripped it can fix it in the same branch.

  CURRENCY (installed vs published) warns everywhere and fails only where a stale catalog actually reaches users: the publish jobs set PI_REGISTRY_CURRENCY_STRICT=1. A red publish is loud, rare, and actionable; a red PR on an unrelated dependency bump is neither.

Also worth recording: Dependabot WILL raise 0.85.1 on its own, because the range is ^0.84.4 and a minor bump falls outside it. The in-range case — 0.84.1 to 0.84.4, which is what went unnoticed for weeks — is the one this check exists for, and a warning surfaces that just as well as a failure did.